### PR TITLE
Add caching to geocode service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 googleCreds.json
+query_sheet.log
+geocodedCache.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 googleCreds.json
 query_sheet.log
-geocodedCache.json
+geocodedCache.db

--- a/get_ad_ed.py
+++ b/get_ad_ed.py
@@ -7,81 +7,81 @@ import sqlite3
 from shapely.geometry import Point, shape
 
 class Gmaps:
-	DATABASE_FILE = 'geocodedCache.db'
+    DATABASE_FILE = 'geocodedCache.db'
 
-	def __init__(self, address, election_district_file, api_key):
-		self.setup_db()
-		self.client = googlemaps.Client(key=api_key)
-		self.geocoded_address = self.get_geocoded_address(address)
-		self.ad, self.ed = self.get_aded(election_district_file)
+    def __init__(self, address, election_district_file, api_key):
+        self.setup_db()
+        self.client = googlemaps.Client(key=api_key)
+        self.geocoded_address = self.get_geocoded_address(address)
+        self.ad, self.ed = self.get_aded(election_district_file)
 
-	def setup_db(self):
-		self.db_connection = sqlite3.connect(self.DATABASE_FILE)
-		self.db_cursor = self.db_connection.cursor()
-		self.find_or_create_table()
+    def setup_db(self):
+        self.db_connection = sqlite3.connect(self.DATABASE_FILE)
+        self.db_cursor = self.db_connection.cursor()
+        self.find_or_create_table()
 
-	def find_or_create_table(self):
-		self.db_cursor.execute("""
-			SELECT name FROM sqlite_master
-			WHERE type='table' AND name='cached_addresses'
-		""").fetchone() or self.db_cursor.execute("""
-			CREATE TABLE cached_addresses(address, longitude, latitude)
-		""")
+    def find_or_create_table(self):
+        self.db_cursor.execute("""
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name='cached_addresses'
+        """).fetchone() or self.db_cursor.execute("""
+            CREATE TABLE cached_addresses(address, longitude, latitude)
+        """)
 
-	def get_aded(self, election_district_file):
-		with open(election_district_file, 'r') as f:
-			for feature in json.load(f)['features']:
-				district_borders = shape(feature['geometry'])
-				if district_borders.contains(self.geocoded_address):
-					aded = feature['properties']['elect_dist']
-					return (self.get_ad(aded), self.get_ed(aded))
+    def get_aded(self, election_district_file):
+        with open(election_district_file, 'r') as f:
+            for feature in json.load(f)['features']:
+                district_borders = shape(feature['geometry'])
+                if district_borders.contains(self.geocoded_address):
+                    aded = feature['properties']['elect_dist']
+                    return (self.get_ad(aded), self.get_ed(aded))
 
-	def get_geocoded_address(self, address):
-		cached_coordinates = self.get_cached_coordinates(address)
-		if cached_coordinates:
-			return Point(*cached_coordinates)
+    def get_geocoded_address(self, address):
+        cached_coordinates = self.get_cached_coordinates(address)
+        if cached_coordinates:
+            return Point(*cached_coordinates)
 
-		coded_address = self.client.geocode(address)
-		if coded_address:
-			location = coded_address[0]['geometry']['location']
-			# shapefile lists lng 1st, lat 2nd
-			coordinates = (location['lng'], location['lat'])
-		else:
-			coordinates = (50,50)
-		self.update_geocode_cache(address, coordinates)
-		return Point(*coordinates)
+        coded_address = self.client.geocode(address)
+        if coded_address:
+            location = coded_address[0]['geometry']['location']
+            # shapefile lists lng 1st, lat 2nd
+            coordinates = (location['lng'], location['lat'])
+        else:
+            coordinates = (50,50)
+        self.update_geocode_cache(address, coordinates)
+        return Point(*coordinates)
 
-	def get_cached_coordinates(self, address):
-		return self.db_cursor.execute(f"""
-			SELECT longitude, latitude FROM cached_addresses
-			WHERE address='{address}'
-		""").fetchone()
+    def get_cached_coordinates(self, address):
+        return self.db_cursor.execute(f"""
+            SELECT longitude, latitude FROM cached_addresses
+            WHERE address='{address}'
+        """).fetchone()
 
-	def update_geocode_cache(self, address, coordinates):
-		self.db_cursor.execute(f"""
-			INSERT INTO cached_addresses VALUES
-			('{address}', {coordinates[0]}, {coordinates[1]})
-		""")
-		self.db_connection.commit()
+    def update_geocode_cache(self, address, coordinates):
+        self.db_cursor.execute(f"""
+            INSERT INTO cached_addresses VALUES
+            ('{address}', {coordinates[0]}, {coordinates[1]})
+        """)
+        self.db_connection.commit()
 
-	def get_ad(self, aded):
-		if str(aded).isdigit() and len(str(aded)) == 5:
-			return str(aded)[:2]
-		return ''
-			
-	def get_ed(self, aded):
-		if str(aded).isdigit() and len(str(aded)) == 5:
-			return str(aded)[2:]
-		return ''
+    def get_ad(self, aded):
+        if str(aded).isdigit() and len(str(aded)) == 5:
+            return str(aded)[:2]
+        return ''
+
+    def get_ed(self, aded):
+        if str(aded).isdigit() and len(str(aded)) == 5:
+            return str(aded)[2:]
+        return ''
 
 
 if __name__ == '__main__':
-	'''
-	pass in arguments separated by spaces after calling the executable, e.g.,
-		./get_ad_ed.py '123 Anywhere Ave, Brooklyn, NY 11221' 'ElectionDistricts.geojson' myspecialapikey
-	'''
-	address, election_district_file, api_key = sys.argv[1:]
+    '''
+    pass in arguments separated by spaces after calling the executable, e.g.,
+        ./get_ad_ed.py '123 Anywhere Ave, Brooklyn, NY 11221' 'ElectionDistricts.geojson' myspecialapikey
+    '''
+    address, election_district_file, api_key = sys.argv[1:]
 
-	maps = Gmaps(address, election_district_file, api_key)
-	print(maps.ad, maps.ed)
-	sys.exit()
+    maps = Gmaps(address, election_district_file, api_key)
+    print(maps.ad, maps.ed)
+    sys.exit()

--- a/get_ad_ed.py
+++ b/get_ad_ed.py
@@ -1,18 +1,30 @@
 #!/usr/bin/env python
 
+import os
 import sys
 import json
 import googlemaps
 from shapely.geometry import Point, shape
 
 class Gmaps:
+	GEOCODED_ADDRESSES_CACHE_FILE = 'geocodedCache.json'
+
 	def __init__(self, address, election_district_file, api_key):
 		self.client = googlemaps.Client(key=api_key)
+		self.cached_coordinates = self.get_geocode_cache()
 		self.geocoded_address = self.get_geocoded_address(address)
 		self.ad, self.ed = self.get_aded(election_district_file)
 
+	def get_geocode_cache(self):
+		if not os.path.isfile(self.GEOCODED_ADDRESSES_CACHE_FILE):
+			f = open(self.GEOCODED_ADDRESSES_CACHE_FILE, 'x')
+			f.close()
+		with open(self.GEOCODED_ADDRESSES_CACHE_FILE, 'r') as f:
+			data = f.read()
+			return json.loads(data) if data else {}
+
 	def get_aded(self, election_district_file):
-		with open(election_district_file) as f:
+		with open(election_district_file, 'r') as f:
 			for feature in json.load(f)['features']:
 				district_borders = shape(feature['geometry'])
 				if district_borders.contains(self.geocoded_address):
@@ -20,6 +32,9 @@ class Gmaps:
 					return (self.get_ad(aded), self.get_ed(aded))
 
 	def get_geocoded_address(self, address):
+		if address in self.cached_coordinates:
+			return Point(*self.cached_coordinates[address])
+
 		coded_address = self.client.geocode(address)
 		if coded_address:
 			location = coded_address[0]['geometry']['location']
@@ -27,7 +42,13 @@ class Gmaps:
 			coordinates = (location['lng'], location['lat'])
 		else:
 			coordinates = (50,50)
+		self.update_geocode_cache(address, coordinates)
 		return Point(*coordinates)
+
+	def update_geocode_cache(self, address, coordinates):
+		self.cached_coordinates[address] = coordinates
+		with open(self.GEOCODED_ADDRESSES_CACHE_FILE, 'w') as f:
+			f.write(json.dumps(self.cached_coordinates, indent=4))
 				
 	def get_ad(self, aded):
 		if str(aded).isdigit() and len(str(aded)) == 5:
@@ -43,9 +64,8 @@ class Gmaps:
 if __name__ == '__main__':
 	'''
 	pass in arguments separated by spaces after calling the executable, e.g.,
-		./get_ad_ed.py '123 Anywhere Ave, Brooklyn, NY 11221' 'Election Districts.geojson' myspecialapikey
+		./get_ad_ed.py '123 Anywhere Ave, Brooklyn, NY 11221' 'ElectionDistricts.geojson' myspecialapikey
 	'''
-	#print(len(sys.argv[1:]),sys.argv[1:])
 	address, election_district_file, api_key = sys.argv[1:]
 
 	maps = Gmaps(address, election_district_file, api_key)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+google_api_python_client==2.65.0
+googlemaps==4.10.0
+protobuf==4.25.2
+Shapely==2.0.2


### PR DESCRIPTION
Making (hundreds of?) thousands of API calls to Google's geocoder on a regular basis gets expensive; as an address doesn't ever change its latitude and longitude, these fresh calls are also gratuitous, and the need for caching becomes readily apparent. This PR implements address geocoding caching.

Included in this PR:
- [x] caching the coordinates returned from the Google geocoder API in a sqlite database
- [x] adding a requirements.txt file (for explicitly defining python dependencies)
- [x] removing the space from the `Election Districts.json` filename
- [x] updating the `.gitignore`
- [x] swapping out tabs for spaces in geocoder python file 