### PR TITLE
Add index for faster queries

### DIFF
--- a/get_ad_ed.py
+++ b/get_ad_ed.py
@@ -26,6 +26,8 @@ class Gmaps:
             WHERE type='table' AND name='cached_addresses'
         """).fetchone() or self.db_cursor.execute("""
             CREATE TABLE cached_addresses(address, longitude, latitude)
+        """) and self.db_cursor.execute("""
+            CREATE INDEX index_address ON cached_addresses(address)
         """)
 
     def get_aded(self, election_district_file):


### PR DESCRIPTION
We might end up with quite a few rows in the DB, so it makes sense to index the `address` so we can look it up in constant time rather than having to scan the entire database for the corresponding record.